### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,7 +178,7 @@ jobs:
       shell: bash
       run: |
         source create-release.env/create-release.env
-        echo "upload_url=$UPLOAD_URL" >> $GITHUB_OUTPUT
+        echo "upload_url=$UPLOAD_URL" >> "$GITHUB_OUTPUT"
       id: env
     - name: Upload ${{ matrix.name }} Release Asset
       uses: actions/upload-release-asset@v1.0.1
@@ -217,7 +217,7 @@ jobs:
   #     shell: bash
   #     run: |
   #       source create-release.env/create-release.env
-  #       echo "upload_url=$UPLOAD_URL" >> $GITHUB_OUTPUT
+  #       echo "upload_url=$UPLOAD_URL" >> "$GITHUB_OUTPUT"
   #     id: env
   #   - name: Upload windows Release Asset
   #     uses: actions/upload-release-asset@v1.0.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,7 +178,7 @@ jobs:
       shell: bash
       run: |
         source create-release.env/create-release.env
-        echo "::set-output name=upload_url::$UPLOAD_URL"
+        echo "upload_url=$UPLOAD_URL" >> $GITHUB_OUTPUT
       id: env
     - name: Upload ${{ matrix.name }} Release Asset
       uses: actions/upload-release-asset@v1.0.1
@@ -217,7 +217,7 @@ jobs:
   #     shell: bash
   #     run: |
   #       source create-release.env/create-release.env
-  #       echo "::set-output name=upload_url::$UPLOAD_URL"
+  #       echo "upload_url=$UPLOAD_URL" >> $GITHUB_OUTPUT
   #     id: env
   #   - name: Upload windows Release Asset
   #     uses: actions/upload-release-asset@v1.0.1

--- a/build/.github/workflows/build.yml
+++ b/build/.github/workflows/build.yml
@@ -165,7 +165,7 @@ jobs:
       shell: bash
       run: |
         source create-release.env/create-release.env
-        echo "upload_url=$UPLOAD_URL" >> $GITHUB_OUTPUT
+        echo "upload_url=$UPLOAD_URL" >> "$GITHUB_OUTPUT"
       id: env
     - name: Upload ${{ matrix.name }} Release Asset
       uses: actions/upload-release-asset@v1.0.1
@@ -204,7 +204,7 @@ jobs:
       shell: bash
       run: |
         source create-release.env/create-release.env
-        echo "upload_url=$UPLOAD_URL" >> $GITHUB_OUTPUT
+        echo "upload_url=$UPLOAD_URL" >> "$GITHUB_OUTPUT"
       id: env
     - name: Upload windows Release Asset
       uses: actions/upload-release-asset@v1.0.1

--- a/build/.github/workflows/build.yml
+++ b/build/.github/workflows/build.yml
@@ -165,7 +165,7 @@ jobs:
       shell: bash
       run: |
         source create-release.env/create-release.env
-        echo "::set-output name=upload_url::$UPLOAD_URL"
+        echo "upload_url=$UPLOAD_URL" >> $GITHUB_OUTPUT
       id: env
     - name: Upload ${{ matrix.name }} Release Asset
       uses: actions/upload-release-asset@v1.0.1
@@ -204,7 +204,7 @@ jobs:
       shell: bash
       run: |
         source create-release.env/create-release.env
-        echo "::set-output name=upload_url::$UPLOAD_URL"
+        echo "upload_url=$UPLOAD_URL" >> $GITHUB_OUTPUT
       id: env
     - name: Upload windows Release Asset
       uses: actions/upload-release-asset@v1.0.1


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


