### PR TITLE
Run unit tests on macOS too

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -27,13 +27,23 @@ permissions:
 
 jobs:
   unittests:
-    runs-on: ubuntu-24.04
+    name: ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: ubuntu-24.04_x86_64
+            os: ubuntu-24.04
+          - target: macos_arm64
+            os: macos-26
     defaults:
       run:
         working-directory: ./build
     steps:
       - uses: actions/checkout@v4
       - name: Disk Cleanup
+        if: runner.os == 'Linux'
         working-directory: ${{ github.workspace }}
         run: |
           df -h
@@ -43,15 +53,20 @@ jobs:
           sudo rm -rf /usr/share/dotnet
           df -h
       - name: Install dependencies
+        if: runner.os == 'Linux'
         run: sudo ./scripts/apt_install_x86_64.sh
       - name: Install test dependencies
+        if: runner.os == 'Linux'
         run: sudo ./scripts/apt_install_test_deps.sh
+      - name: Select Xcode 26.0
+        if: runner.os == 'macOS'
+        run: sudo xcode-select --switch /Applications/Xcode_26.0.app/Contents/Developer
       - name: Build and run unittests
         env:
           COMMIT_HASH: ${{ github.event.inputs.commitHash }}
         run: |
           if [ -n "$COMMIT_HASH" ]; then
-            python3 run.py build ubuntu-24.04_x86_64 --debug --test --commit "$COMMIT_HASH"
+            python3 run.py build ${{ matrix.target }} --debug --test --commit "$COMMIT_HASH"
           else
-            python3 run.py build ubuntu-24.04_x86_64 --debug --test
+            python3 run.py build ${{ matrix.target }} --debug --test
           fi

--- a/build/run.py
+++ b/build/run.py
@@ -753,7 +753,12 @@ def build_webrtc(
                 'rtc_libvpx_build_vp9=true',
                 'rtc_enable_symbol_export=true',
                 'rtc_enable_objc_symbol_export=false',
-                'use_custom_libcxx=false',
+                # The clang module build of libc++ needs the include config that
+                # use_custom_libcxx=false removes, and fails with "unknown type
+                # name 'size_t'". apple/xcframework.sh builds the shipped macOS
+                # slices with the default (custom) libc++, so do the same here
+                # when building tests; packaged libs keep the system libc++.
+                f'use_custom_libcxx={"true" if test else "false"}',
                 'treat_warnings_as_errors=false',
                 'clang_use_chrome_plugins=false',
                 'use_lld=false',

--- a/build/run.py
+++ b/build/run.py
@@ -747,10 +747,10 @@ def build_webrtc(
             gn_args += [
                 'target_os="mac"',
                 f'target_cpu="{"x64" if target == "macos_x86_64" else "arm64"}"',
-                # 10.11 no longer compiles: abseil uses aligned operator new,
-                # which clang only allows from 10.13. Match the deployment
-                # target apple/xcframework.sh ships the macOS slices with.
-                'mac_deployment_target="10.15"',
+                # No mac_deployment_target: inherit build/'s own default (12.0),
+                # which is the oldest macOS the toolchain still tests. The old
+                # 10.11 pin stopped compiling (abseil needs aligned operator
+                # new, 10.13+).
                 'enable_stripping=true',
                 'enable_dsyms=true',
                 'rtc_libvpx_build_vp9=true',

--- a/build/run.py
+++ b/build/run.py
@@ -747,7 +747,10 @@ def build_webrtc(
             gn_args += [
                 'target_os="mac"',
                 f'target_cpu="{"x64" if target == "macos_x86_64" else "arm64"}"',
-                'mac_deployment_target="10.11"',
+                # 10.11 no longer compiles: abseil uses aligned operator new,
+                # which clang only allows from 10.13. Match the deployment
+                # target apple/xcframework.sh ships the macOS slices with.
+                'mac_deployment_target="10.15"',
                 'enable_stripping=true',
                 'enable_dsyms=true',
                 'rtc_libvpx_build_vp9=true',


### PR DESCRIPTION
Convert the unittests job to a matrix over run.py build targets, adding macos_arm64 alongside ubuntu-24.04_x86_64. run.py already supports --test for the macos targets, so no build script changes are needed.