### PR TITLE
Publish xcframework to livekit/webrtc-xcframework on release

### DIFF
--- a/.github/templates/LiveKitWebRTC.podspec
+++ b/.github/templates/LiveKitWebRTC.podspec
@@ -1,0 +1,30 @@
+Pod::Spec.new do |spec|
+  spec.name = "LiveKitWebRTC"
+  spec.version = "{{VERSION}}"
+  spec.summary = "Custom WebRTC build for LiveKit"
+  spec.description = <<-DESC
+    LiveKit version Dynamic WebRTC XCFramework
+    * Framework is renamed to LiveKitWebRTC.
+    * Objective-C symbols are prefixed with LK, for example LKRTCPeerConnection.
+  DESC
+
+  spec.homepage = "https://github.com/livekit/webrtc-xcframework"
+  spec.license = {:type => "BSD", :file => "LiveKitWebRTC.xcframework/LICENSE"}
+  spec.author = "LiveKit"
+
+  spec.ios.deployment_target = "13.0"
+  spec.osx.deployment_target = "10.15"
+  spec.tvos.deployment_target = "17.0"
+  spec.visionos.deployment_target = "26.0"
+
+  spec.source = {
+    :http => "https://github.com/livekit/webrtc-xcframework/releases/download/{{VERSION}}/LiveKitWebRTC.xcframework.zip"
+  }
+  spec.vendored_frameworks = "LiveKitWebRTC.xcframework"
+
+  # Exclude architectures for specific platforms
+  spec.pod_target_xcconfig = {
+    'EXCLUDED_ARCHS[sdk=appletvsimulator*]' => 'x86_64',
+    'EXCLUDED_ARCHS[sdk=xrsimulator*]' => 'x86_64'
+  }
+end

--- a/.github/templates/Package.swift
+++ b/.github/templates/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version:5.9
+// (Xcode15.0+)
+
+import PackageDescription
+
+let package = Package(
+    name: "LiveKitWebRTC",
+    platforms: [
+        .iOS(.v13),
+        .macOS(.v10_15),
+        .macCatalyst(.v14),
+    ],
+    products: [
+        .library(
+            name: "LiveKitWebRTC",
+            targets: ["LiveKitWebRTC"]
+        ),
+    ],
+    dependencies: [],
+    targets: [
+        .binaryTarget(
+            name: "LiveKitWebRTC",
+            url: "https://github.com/livekit/webrtc-xcframework/releases/download/{{VERSION}}/LiveKitWebRTC.xcframework.zip",
+            checksum: "{{CHECKSUM}}"
+        ),
+    ]
+)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,3 +102,37 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         files: artifacts/**
+  publish-xcframework:
+    name: Publish
+    if: github.ref_type == 'tag'
+    needs:
+      - create-release
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/download-artifact@v4
+      with:
+        path: artifacts
+        name: LiveKitWebRTC.xcframework.zip
+    - name: Render Package.swift and podspec
+      id: render
+      run: |
+        # Build tags are prefixed with m (m144.7559.13); hosting repo tags are not.
+        VERSION="${GITHUB_REF_NAME#m}"
+        CHECKSUM=$(sha256sum artifacts/LiveKitWebRTC.xcframework.zip | awk '{print $1}')
+        echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+        mkdir -p out
+        for f in Package.swift LiveKitWebRTC.podspec; do
+          sed -e "s|{{VERSION}}|${VERSION}|g" \
+              -e "s|{{CHECKSUM}}|${CHECKSUM}|g" \
+              ".github/templates/$f" > "out/$f"
+        done
+    - uses: livekit/publish-xcframework-action@3b8645334fb62b0fd1d7067067819bcd111db157 # main
+      with:
+        xcframework-zip: artifacts/LiveKitWebRTC.xcframework.zip
+        version: ${{ steps.render.outputs.version }}
+        hosting-repo: livekit/webrtc-xcframework
+        files: |
+          out/Package.swift:Package.swift
+          out/LiveKitWebRTC.podspec:LiveKitWebRTC.podspec
+        token: ${{ secrets.XCFRAMEWORK_PAT }}


### PR DESCRIPTION
Adds a `Publish` job after `Create Release` that renders `Package.swift`/`LiveKitWebRTC.podspec` from templates and opens a draft release + PR on [livekit/webrtc-xcframework](https://github.com/livekit/webrtc-xcframework), replacing the manual step (e.g. [#32](https://github.com/livekit/webrtc-xcframework/pull/32)).

> [!IMPORTANT]
> Requires a new `XCFRAMEWORK_PAT` repo secret — a fine-grained PAT scoped to the **other org's** repo `livekit/webrtc-xcframework` with **Contents: Read and write** and **Pull requests: Read and write**. The job fails at the clone step without it.